### PR TITLE
Add stricter version of `parseFloat()`: `stringToNumber()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc",
     "test": "jest",
+    "test-watch": "jest --watch",
     "coverage": "jest --coverage",
     "build:doc": "npm run build & ts-node src/dev/jsdoc.ts",
     "buildAndPublish": "rm -rf dist && npm run build:doc && npm version patch && git push && npm publish"

--- a/src/misc/stringToNumber.ts
+++ b/src/misc/stringToNumber.ts
@@ -1,0 +1,9 @@
+/** Returns a numeric representation of an input string.
+ * The string represents one or more digits, with exactly one
+ * optional decimal place, at any location in the string.
+ * This may return NaN.
+ * @param str String that represents a number, optionally with one decimal place.
+ * */
+export const stringToNumber = (str: string): number => (
+  /^((\d+(\.\d*)?)|\.\d+)$/.test(str) ? parseFloat(str) : NaN
+);

--- a/src/misc/stringToNumber.ts
+++ b/src/misc/stringToNumber.ts
@@ -1,9 +1,8 @@
 /**
- * Returns a numeric representation of an input string.
- * The string represents one or more digits, with exactly one
- * optional decimal place, at any location in the string.
- * This may return NaN.
- * @param str String that represents a number, optionally with one decimal place.
+ * Returns a numeric representation of an input string or `NaN` if the provided string value is not valid.
+ * The string should consist one or more digits, with zero or one decimal point (period) within the string.
+ * If the string does not match this pattern, this function will return `NaN`.
+ * @param str String that should represent a number, with one optional decimal point.
  */
 export const stringToNumber = (str: string): number => (
   /^((\d+(\.\d*)?)|\.\d+)$/.test(str) ? parseFloat(str) : NaN

--- a/src/misc/stringToNumber.ts
+++ b/src/misc/stringToNumber.ts
@@ -1,9 +1,10 @@
-/** Returns a numeric representation of an input string.
+/**
+ * Returns a numeric representation of an input string.
  * The string represents one or more digits, with exactly one
  * optional decimal place, at any location in the string.
  * This may return NaN.
  * @param str String that represents a number, optionally with one decimal place.
- * */
+ */
 export const stringToNumber = (str: string): number => (
   /^((\d+(\.\d*)?)|\.\d+)$/.test(str) ? parseFloat(str) : NaN
 );

--- a/src/miscellaneous.ts
+++ b/src/miscellaneous.ts
@@ -30,6 +30,7 @@ export { notEmpty } from './misc/notEmpty';
 export { notNull } from './misc/notNull';
 export { sameType } from './misc/sameType';
 export { stringToBool } from './misc/stringToBool';
+export { stringToNumber } from './misc/stringToNumber';
 export { strVal } from './misc/strVal';
 export { undef, notDef, isUndefined } from './misc/undef';
 export { typeCast } from './misc/typeCast';

--- a/tests/miscellaneous.test.ts
+++ b/tests/miscellaneous.test.ts
@@ -2,7 +2,7 @@ import {
   isNull, notNull, empty, notEmpty, boolVal, floatVal, strVal, isValidNumber,
   isIntegerNumber, isNumeric, isString, isBigInt, isSymbol, isBoolean,
   isPrimitive, isReference, envToType, intVal, sameType, isValidJSON,
-  typeCast, clamp,
+  typeCast, clamp, stringToNumber,
 } from '../src/miscellaneous';
 
 describe('Miscellaneous functions', () => {
@@ -58,6 +58,28 @@ describe('Miscellaneous functions', () => {
     expect(floatVal(123)).toBe(123);
     expect(floatVal('aaa')).toBeNaN();
     expect(floatVal(undefined)).toBeNaN();
+  });
+  test('stringToNumber', async () => {
+    expect(stringToNumber('123')).toBe(123);
+    expect(stringToNumber('0')).toBe(0);
+    expect(stringToNumber('0.0')).toBe(0);
+    expect(stringToNumber('.123')).toBe(0.123);
+    expect(stringToNumber('123.')).toBe(123);
+    expect(stringToNumber('12.3')).toBe(12.3);
+    expect(stringToNumber('00001')).toBe(1);
+    expect(stringToNumber('000.1')).toBe(0.1);
+    expect(stringToNumber('123 ')).toBeNaN();
+    expect(stringToNumber(' 123')).toBeNaN();
+    expect(stringToNumber('12 3')).toBeNaN();
+    expect(stringToNumber('10e3')).toBeNaN();
+    expect(stringToNumber('a123')).toBeNaN();
+    expect(stringToNumber('123z')).toBeNaN();
+    expect(stringToNumber('1.23.')).toBeNaN();
+    expect(stringToNumber('..123')).toBeNaN();
+    expect(stringToNumber('123..')).toBeNaN();
+    expect(stringToNumber('$123')).toBeNaN();
+    expect(stringToNumber('0x101')).toBeNaN();
+    expect(stringToNumber('0b101')).toBeNaN();
   });
   test('strVal', async () => {
     expect(strVal([1, 2, 3])).toBe(JSON.stringify([1, 2, 3]));


### PR DESCRIPTION
Included tests.

Added `test-watch` script in `package.json`.