### PR TITLE
Add sorting function that can handle `null` and `undefined` values

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -55,6 +55,7 @@ export { min } from './arrays/min';
 export { moveElement } from './arrays/moveElement';
 export { multiPartition } from './arrays/multiPartition';
 export { notIntersect } from './arrays/notIntersect';
+export { nullishSort } from './arrays/nullishSort';
 export { omit } from './arrays/omit';
 export { partition } from './arrays/partition';
 export { pickEach } from './arrays/pickEach';

--- a/src/arrays/nullishSort.ts
+++ b/src/arrays/nullishSort.ts
@@ -1,0 +1,76 @@
+/* eslint-disable no-continue */
+
+type TSortable = number | null | undefined;
+
+type TNullishPlacement = 'first' | 'last' | 'omit';
+
+/**
+ * Merges two sorted arrays. These arrays may contain `null` or `undefined`.
+ * @param left First sorted array.
+ * @param right Second sorted array.
+ * @param nullishPlacement Whether to omit or place null-ish values at the
+ * start or end of the sorted array.
+ */
+export const mergeSortedArrays = (
+  left: TSortable[],
+  right: TSortable[],
+  nullishPlacement: TNullishPlacement = 'omit',
+): TSortable[] => {
+  let i = 0;
+  let j = 0;
+
+  const merged: number[] = [];
+  const leftNullishValues: TSortable[] = [];
+  const rightNullishValues: TSortable[] = [];
+
+  while (i < left.length || j < right.length) {
+    if (left[i] == null && i < left.length) {
+      leftNullishValues.push(left[i++]);
+      continue;
+    }
+
+    if (right[j] == null && j < right.length) {
+      rightNullishValues.push(right[j++]);
+      continue;
+    }
+
+    if (right[j] == null || (left[i] ?? Infinity) < (right[j] ?? Infinity)) {
+      merged.push(left[i++]!);
+    } else {
+      merged.push(right[j++]!);
+    }
+  }
+
+  return [
+    ...(nullishPlacement === 'first' ? leftNullishValues.concat(rightNullishValues) : []),
+    ...merged,
+    ...(nullishPlacement === 'last' ? leftNullishValues.concat(rightNullishValues) : []),
+  ];
+};
+
+/**
+ * Sorts an array of numbers that possibly contain numerous `null` or `undefined` values.
+ * Uses an adaptation of the merge-sort algorithm that is stable, meaning that equal
+ * numbers, and `null` and `undefined` values, retain their original relative positioning.
+ * @param items Array of numbers, possibly including `null` or `undefined` values.
+ * @param nullishPlacement Whether to omit or place null-ish values at the
+ * start or end of the sorted array.
+ */
+export const nullishSort = (
+  items: TSortable[],
+  nullishPlacement: TNullishPlacement = 'omit',
+): TSortable[] => {
+  if (items.length === 1) {
+    return items;
+  }
+
+  const middle = Math.floor(items.length / 2);
+
+  return (
+    mergeSortedArrays(
+      nullishSort(items.slice(0, middle), nullishPlacement),
+      nullishSort(items.slice(middle), nullishPlacement),
+      nullishPlacement,
+    )
+  );
+};


### PR DESCRIPTION
Hey James,

Here is an implementation of the sorting function that we recently discussed.
It can handle `null` and `undefined` values in a stable manner.
The user can choose to omit such values (default behavior), or place them at the start or end of the resulting sorted array.

If you dislike the inline `i++`, let me know and I will change them.
I can also be more explicit with the `== null`, if you wish.

Finally, in `merge_sorted_arrays()`, I was unable to satisfy TypeScript without use of the non-null assertion operator. Let me know if you have a way to do so!

Tests included :)