### PR TITLE
Ensure that `0` values aren't turned into empty strings when using `strVal`

### DIFF
--- a/src/misc/strVal.ts
+++ b/src/misc/strVal.ts
@@ -3,9 +3,10 @@ import { isDefinedObject } from '../objects/isDefinedObject';
 
 /**
  * Returns an appropriate string value for `x`. If `x` is an array or object, this will be a JSON
- * representation. `null` and `undefined` will be converted to an empty string. Otherwise this will
- * return the result of built in .toString().
+ * representation. All falsy values other than `0` will be converted to an empty string.
+ * Otherwise this will return the result of built in .toString().
+ * @param x
  */
 export const strVal = (
   x: unknown,
-): string => ((isDefinedObject(x) || isArray(x)) ? JSON.stringify(x) : `${x || ''}`);
+): string => ((isDefinedObject(x) || isArray(x)) ? JSON.stringify(x) : `${x === 0 ? x : (x || '')}`);

--- a/tests/miscellaneous.test.ts
+++ b/tests/miscellaneous.test.ts
@@ -64,6 +64,11 @@ describe('Miscellaneous functions', () => {
     expect(strVal({ a: 1, b: 2, c: 3 })).toBe(JSON.stringify({ a: 1, b: 2, c: 3 }));
     expect(strVal(undefined)).toBe('');
     expect(strVal(null)).toBe('');
+    expect(strVal(0)).toBe('0');
+    expect(strVal(7)).toBe('7');
+    expect(strVal(NaN)).toBe('');
+    expect(strVal(false)).toBe('');
+    expect(strVal(true)).toBe('true');
   });
   test('intVal', async () => {
     expect(intVal([1, 2, 3])).toBe(1);


### PR DESCRIPTION
Hey James,

I made a small tweak to `strVal()` to avoid parsing `0` as an empty string, and added a few relevant tests.

Brendan